### PR TITLE
chore(deps): bump rabbitmq and mariadb image digests (manual, bypass Renovate cache)

### DIFF
--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mariadb
 description: MariaDB relational database
 type: application
-version: "0.4.3"
+version: "0.4.4"
 appVersion: "12.2.2"
 icon: https://cdn.simpleicons.org/mariadb
 home: https://github.com/kubelauncher/charts
@@ -25,4 +25,4 @@ annotations:
     url: https://kubelauncher.github.io/charts/cosign.pub
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump default resourcesPreset from nano to micro
+      description: Rebuild mariadb image (updated base OS)

--- a/charts/mariadb/README.md
+++ b/charts/mariadb/README.md
@@ -107,7 +107,7 @@ helm uninstall my-mariadb
 | global.mariadb.auth.username | string | `""` |  |
 | global.mariadb.service.ports.mariadb | string | `""` |  |
 | global.storageClass | string | `""` |  |
-| image.digest | string | `"sha256:a87d1c4fea87a97deded02f0edbfbf764c0433c25d72eb8659383e492900655c"` |  |
+| image.digest | string | `"sha256:6dfa892113de98a7988489b01ee86309ccf5e8abab26461884c56d5021ca37be"` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.pullSecrets | list | `[]` |  |
 | image.registry | string | `"ghcr.io"` |  |

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -39,7 +39,7 @@ image:
   repository: kubelauncher/mariadb
   # renovate: image=ghcr.io/kubelauncher/mariadb
   tag: "12.2.2"
-  digest: "sha256:a87d1c4fea87a97deded02f0edbfbf764c0433c25d72eb8659383e492900655c"
+  digest: "sha256:6dfa892113de98a7988489b01ee86309ccf5e8abab26461884c56d5021ca37be"
   pullPolicy: Always
   pullSecrets: []
 

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: RabbitMQ message broker
 type: application
-version: "0.1.19"
+version: "0.1.20"
 appVersion: "4.2.5"
 icon: https://cdn.simpleicons.org/rabbitmq
 home: https://github.com/kubelauncher/charts
@@ -24,5 +24,5 @@ annotations:
     fingerprint: EE19FA216B8349AC017C5279B4C062080CDC2061C264EE92CF98300E39FD40A8
     url: https://kubelauncher.github.io/charts/cosign.pub
   artifacthub.io/changes: |
-    - kind: added
-      description: Add Prometheus metrics via native plugin and ServiceMonitor
+    - kind: changed
+      description: Rebuild rabbitmq image (fixes version drift, now ships actual 4.2.5 instead of Ubuntu 3.12.1)

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -126,7 +126,7 @@ helm uninstall my-rmq
 | httpRoute.parentRefs.namespace | string | `"traefik"` |  |
 | httpRoute.path | string | `"/"` |  |
 | httpRoute.pathType | string | `"PathPrefix"` |  |
-| image.digest | string | `"sha256:adeeff0be56316fbcac66eb797c98db75c609acc472805227c43c5e4276c4a2a"` |  |
+| image.digest | string | `"sha256:8ee82ebdf285c19ff05351e66f2079d1717e6351cced68ef78f41cc23023daa9"` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.pullSecrets | list | `[]` |  |
 | image.registry | string | `"ghcr.io"` |  |

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -23,7 +23,7 @@ image:
   repository: kubelauncher/rabbitmq
   # renovate: image=ghcr.io/kubelauncher/rabbitmq
   tag: "4.2.5"
-  digest: "sha256:adeeff0be56316fbcac66eb797c98db75c609acc472805227c43c5e4276c4a2a"
+  digest: "sha256:8ee82ebdf285c19ff05351e66f2079d1717e6351cced68ef78f41cc23023daa9"
   pullPolicy: Always
   pullSecrets: []
 


### PR DESCRIPTION
## Summary

Manual digest bump for rabbitmq and mariadb charts. Mend-hosted Renovate's datasource cache did not pick up the new image digests after [kubelauncher/docker#65](https://github.com/kubelauncher/docker/pull/65) rebuilt both images.

## Changes

**values.yaml digests:**
- `rabbitmq`: `adeeff0b…` → `8ee82ebd…`
- `mariadb`: `a87d1c4f…` → `6dfa8921…`

**Chart.yaml patch bump (digest-only convention):**
- `rabbitmq`: 0.1.19 → 0.1.20
- `mariadb`: 0.4.3 → 0.4.4

**Context:**
The rabbitmq image previously shipped Ubuntu's `rabbitmq-server` 3.12.1 instead of the expected 4.2.5 because the old upstream PPA URL no longer resolved and apt silently fell back to the Ubuntu archive. kubelauncher/docker#65 fixed that with new upstream URLs + a madison version guard. This chart PR ships the corrected image digest to consumers.

## Test plan

- [x] `helm lint charts/rabbitmq charts/mariadb` → 0 failures
- [x] `helm-docs` + `helm-values-schema-json` regenerated
- [ ] CI green (Integration Tests, Security Scan)
- [ ] Release workflow publishes 0.1.20 + 0.4.4 to GHCR OCI + Pages index