### PR TITLE
chore(rabbitmq): bump digest to restore arm64 support

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: RabbitMQ message broker
 type: application
-version: "0.1.20"
+version: "0.1.21"
 appVersion: "4.2.5"
 icon: https://cdn.simpleicons.org/rabbitmq
 home: https://github.com/kubelauncher/charts

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -126,7 +126,7 @@ helm uninstall my-rmq
 | httpRoute.parentRefs.namespace | string | `"traefik"` |  |
 | httpRoute.path | string | `"/"` |  |
 | httpRoute.pathType | string | `"PathPrefix"` |  |
-| image.digest | string | `"sha256:8ee82ebdf285c19ff05351e66f2079d1717e6351cced68ef78f41cc23023daa9"` |  |
+| image.digest | string | `"sha256:a322afb1b96c062f34079af8c1a00cbd297576ec80a06682fb2d3e11e16b15d7"` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.pullSecrets | list | `[]` |  |
 | image.registry | string | `"ghcr.io"` |  |

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -23,7 +23,7 @@ image:
   repository: kubelauncher/rabbitmq
   # renovate: image=ghcr.io/kubelauncher/rabbitmq
   tag: "4.2.5"
-  digest: "sha256:8ee82ebdf285c19ff05351e66f2079d1717e6351cced68ef78f41cc23023daa9"
+  digest: "sha256:a322afb1b96c062f34079af8c1a00cbd297576ec80a06682fb2d3e11e16b15d7"
   pullPolicy: Always
   pullSecrets: []
 


### PR DESCRIPTION
Pulls docker#66 rebuild. Restores arm64 manifest (fixes client ImagePullBackOff on Graviton).

- Chart: 0.1.20 -> 0.1.21
- Digest: `sha256:8ee82ebdf285c19ff05351e66f2079d1717e6351cced68ef78f41cc23023daa9` -> `sha256:a322afb1b96c062f34079af8c1a00cbd297576ec80a06682fb2d3e11e16b15d7`
- Multi-arch verified: amd64,arm64