### PR TITLE
fix(mysql): pin digest to multi-arch index (restore arm64 support)

### DIFF
--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mysql
 description: MySQL relational database
 type: application
-version: "0.3.3"
+version: "0.3.4"
 appVersion: "8.0.45"
 icon: https://cdn.simpleicons.org/mysql
 home: https://github.com/kubelauncher/charts
@@ -23,5 +23,5 @@ annotations:
     fingerprint: EE19FA216B8349AC017C5279B4C062080CDC2061C264EE92CF98300E39FD40A8
     url: https://kubelauncher.github.io/charts/cosign.pub
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump default resourcesPreset from nano to micro
+    - kind: fixed
+      description: Pin image digest to the multi-arch manifest index (previous digest pointed to an amd64-only leaf, breaking arm64 pulls)

--- a/charts/mysql/README.md
+++ b/charts/mysql/README.md
@@ -107,7 +107,7 @@ helm uninstall my-mysql
 | global.mysql.auth.username | string | `""` |  |
 | global.mysql.service.ports.mysql | string | `""` |  |
 | global.storageClass | string | `""` |  |
-| image.digest | string | `"sha256:22fe047da651cd5cb3a8374abdb4269215010f360ac83e9d9503766643fad9b8"` |  |
+| image.digest | string | `"sha256:53ecb5e618789ac347dd4bd4c6ab575f5d353f14adc94497c9b7e07a42018799"` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.pullSecrets | list | `[]` |  |
 | image.registry | string | `"ghcr.io"` |  |

--- a/charts/mysql/values.yaml
+++ b/charts/mysql/values.yaml
@@ -39,7 +39,7 @@ image:
   repository: kubelauncher/mysql
   # renovate: image=ghcr.io/kubelauncher/mysql
   tag: "8.0.45"
-  digest: "sha256:22fe047da651cd5cb3a8374abdb4269215010f360ac83e9d9503766643fad9b8"
+  digest: "sha256:53ecb5e618789ac347dd4bd4c6ab575f5d353f14adc94497c9b7e07a42018799"
   pullPolicy: Always
   pullSecrets: []
 


### PR DESCRIPTION
Same class of bug as rabbitmq: the digest pinned in mysql chart was a leaf amd64 manifest, not the OCI image index. arm64 pulls fail with "no match for platform in manifest".

## Changes
- mysql values.yaml: `sha256:22fe047d…` (amd64 leaf) -> `sha256:53ecb5e6…` (multi-arch index)
- mysql chart: 0.3.3 -> 0.3.4 (patch)

## Why Renovate produced a leaf digest for mysql specifically
Under investigation. The regex + datasource config is identical to the other 13 charts (which all correctly pin index digests). Historical mysql PRs (#142, #120, #109) also pinned leaf digests — so this is a persistent bug, not a one-off.

Follow-up PR will add a CI guard in kubelauncher/docker that fails the build if the published manifest is not a multi-arch index (amd64 + arm64).