### PR TITLE
fix: bump rabbitmq and cassandra digests with entrypoint fixes

### DIFF
--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cassandra
 description: Apache Cassandra distributed NoSQL database
 type: application
-version: "0.1.18"
+version: "0.1.19"
 appVersion: "5.0.7"
 icon: https://cdn.simpleicons.org/apachecassandra
 home: https://github.com/kubelauncher/charts
@@ -25,4 +25,4 @@ annotations:
     url: https://kubelauncher.github.io/charts/cosign.pub
   artifacthub.io/changes: |
     - kind: added
-      description: Add GPG provenance signing for Helm repo
+      description: Add CASSANDRA_REPLACE_ADDRESS env var for pod rejoin failures in Kubernetes

--- a/charts/cassandra/values.yaml
+++ b/charts/cassandra/values.yaml
@@ -23,7 +23,7 @@ image:
   repository: kubelauncher/cassandra
   # renovate: image=ghcr.io/kubelauncher/cassandra
   tag: "5.0.7"
-  digest: "sha256:5c0cacb51b5eb483613ab3e27cbee23df34d45459d0c0c3abce3cd9176a5b0cb"
+  digest: "sha256:de5c56be1ceb37127b9704941d5645f03c334697e3b30c0520bb3c39fb2ce244"
   pullPolicy: Always
   pullSecrets: []
 

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: RabbitMQ message broker
 type: application
-version: "0.1.22"
+version: "0.1.23"
 appVersion: "4.2.5"
 icon: https://cdn.simpleicons.org/rabbitmq
 home: https://github.com/kubelauncher/charts
@@ -24,5 +24,5 @@ annotations:
     fingerprint: EE19FA216B8349AC017C5279B4C062080CDC2061C264EE92CF98300E39FD40A8
     url: https://kubelauncher.github.io/charts/cosign.pub
   artifacthub.io/changes: |
-    - kind: changed
-      description: Rebuild rabbitmq image (fixes version drift, now ships actual 4.2.5 instead of Ubuntu 3.12.1)
+    - kind: added
+      description: Add RABBITMQ_FORCE_RESET env var for major-version upgrade recovery (3.12→4.x)

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -23,7 +23,7 @@ image:
   repository: kubelauncher/rabbitmq
   # renovate: image=ghcr.io/kubelauncher/rabbitmq
   tag: "4.2.5"
-  digest: "sha256:12a711e16d208a55b3a5e52107059bd5ecd56592195ead6238e1bd93d2270596"
+  digest: "sha256:4368f34a93e62e55af650883d0fe55f03f1f27a78f0d414bbc0dfb48ae401362"
   pullPolicy: Always
   pullSecrets: []
 


### PR DESCRIPTION
## Summary

- Bumps RabbitMQ chart `0.1.22` → `0.1.23` with new image digest including `RABBITMQ_FORCE_RESET` entrypoint support
- Bumps Cassandra chart `0.1.18` → `0.1.19` with new image digest including `CASSANDRA_REPLACE_ADDRESS` entrypoint support

## Context

Docker entrypoint fixes merged in kubelauncher/docker:
- kubelauncher/docker#75 — RabbitMQ: handle 3.12→4.x Mnesia incompatibility via force reset
- kubelauncher/docker#76 — Cassandra: handle endpoint collision on pod rejoin via replace_address

This PR updates the chart image digests to pick up those fixes.

## Test plan

- [ ] `helm template` both charts — verify no rendering errors
- [ ] Deploy RabbitMQ with `RABBITMQ_FORCE_RESET=true` via `extraEnvVars` — verify Mnesia reset and clean start
- [ ] Deploy Cassandra with `CASSANDRA_REPLACE_ADDRESS=auto` via `extraEnvVars` — verify node replacement on rejoin

🤖 Generated with [Claude Code](https://claude.com/claude-code)