### PR TITLE
ci(release): serialize release runs to avoid gh-pages push races

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,13 @@ permissions:
   pages: write
   id-token: write
 
+# Serialize releases so concurrent runs never race on the gh-pages push.
+# The "Check for already published charts" step is registry-driven and
+# idempotent, so a superseded pending run is safely caught up by the next one.
+concurrency:
+  group: release-charts
+  cancel-in-progress: false
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Merging several chart PRs in quick succession triggered multiple concurrent `Release Charts` runs. They raced on the `gh-pages` push and one failed with:

```
! [rejected]        gh-pages -> gh-pages (fetch first)
error: failed to push some refs
```

OCI packaging/signing/push to GHCR had already succeeded — only the GitHub Pages Helm index push lost the race.

## Fix

Add a workflow-level `concurrency` group so `Release Charts` runs one at a time:

```yaml
concurrency:
  group: release-charts
  cancel-in-progress: false
```

The `Check for already published charts` step is registry-driven and idempotent, so if a pending run is superseded, the next run still catches up any not-yet-published chart — no release is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)